### PR TITLE
Fixed misplaced compiler directive go:notinheap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module github.com/demdxx/iprangetree
+module github.com/tumani1/iprangetree
 
-require github.com/google/btree v1.0.0 // indirect
+go 1.15
+
+require github.com/google/btree v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tumani1/iprangetree
+module github.com/demdxx/iprangetree
 
 go 1.15
 

--- a/helpers.go
+++ b/helpers.go
@@ -10,7 +10,6 @@ import (
 )
 
 // We awaiting IPv4 as size 4 and IPv6 as size 16
-//go:notinheap
 func compare(ip1, ip2 net.IP) int {
 	if len(ip1) > len(ip2) {
 		return 1
@@ -28,7 +27,6 @@ func compare(ip1, ip2 net.IP) int {
 	return 0
 }
 
-//go:notinheap
 func lastIP(ip net.IP, mask net.IPMask) net.IP {
 	var (
 		n   = len(mask)

--- a/ip_fix.go
+++ b/ip_fix.go
@@ -49,7 +49,6 @@ func (ip ipFix) IsEmpty() bool {
 	return ip[net.IPv6len] == 0
 }
 
-//go:notinheap
 func (ip *ipFix) Compare(ip2 *ipFix) (result int) {
 	i := 0
 	if v1, v2 := ip.IsIPv4(), ip2.IsIPv4(); !v1 && v2 {
@@ -85,7 +84,6 @@ func (ip ipFix) IPv4() ipV4 {
 }
 
 // Less camparing for btree
-//go:notinheap
 func (ip *ipFix) Less(then btree.Item) bool {
 	switch v := then.(type) {
 	case *IPItemFix:

--- a/ip_v4.go
+++ b/ip_v4.go
@@ -41,7 +41,6 @@ func (ip ipV4) IP() net.IP {
 }
 
 // Less camparing for btree
-//go:notinheap
 func (ip ipV4) Less(then btree.Item) bool {
 	switch v := then.(type) {
 	case *IPItemFix:

--- a/tree.go
+++ b/tree.go
@@ -112,7 +112,6 @@ func (t *IPTree) LookupByString(ip string) IPItemAccessor {
 }
 
 // Lookup to search the IP value in the IP tree
-//go:notinheap
 func (t *IPTree) Lookup(ip net.IP) (response IPItemAccessor) {
 	ipFix := ip2fix(ip)
 


### PR DESCRIPTION
**Golang version:**
go1.15.2

In golang v1.15 was merged this functional https://go-review.googlesource.com/c/go/+/228578/
I have a problem with execute `go get` and `go build` commands.

**Error log:**
```
> go get -u github.com/demdxx/iprangetree
# github.com/demdxx/iprangetree
go/src/github.com/demdxx/iprangetree/helpers.go:13:3: misplaced compiler directive
go/src/github.com/demdxx/iprangetree/helpers.go:31:3: misplaced compiler directive
go/src/github.com/demdxx/iprangetree/ip_fix.go:52:3: misplaced compiler directive
go/src/github.com/demdxx/iprangetree/ip_fix.go:88:3: misplaced compiler directive
go/src/github.com/demdxx/iprangetree/ip_v4.go:44:3: misplaced compiler directive
go/src/github.com/demdxx/iprangetree/tree.go:115:3: misplaced compiler directive

```

**Fix:**
- removed misplaced compiler directives go:notinheap


